### PR TITLE
Fixing the day filtering

### DIFF
--- a/python/power/templates/index.html
+++ b/python/power/templates/index.html
@@ -18,11 +18,11 @@
             </tr>
         </thead>
         <tbody>
-        {% for tick in ticks %}
+        {% for pulse in pulses %}
             <tr>
-                <td>{{ "{:%H:%M:%S}".format(tick['timestamp']) }}</td>
-                <td class="number">{{ "{:.1f}W".format(tick['power']) }}</td>
-                <td class="number">{{ "{:.3f}s".format(tick['duration']) }}</td>
+                <td>{{ "{:%H:%M:%S}".format(pulse['timestamp']) }}</td>
+                <td class="number">{{ "{:.1f}W".format(pulse['power']) }}</td>
+                <td class="number">{{ "{:.3f}s".format(pulse['duration']) }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/python/power/ticks_to_pulse.py
+++ b/python/power/ticks_to_pulse.py
@@ -1,0 +1,56 @@
+# one time conversion script from the old structure to the new structure
+
+import datetime
+import os
+from dateutil import tz
+import sqlite3
+from pathlib import Path
+
+
+def get_db():
+    db = create_connection()
+    db.row_factory = sqlite3.Row
+    return db
+
+
+def query_db(query, args=(), one=False):
+    cur = get_db().execute(query, args)
+    rv = cur.fetchall()
+    cur.close()
+    return (rv[0] if rv else None) if one else rv
+
+
+def get_data_path():
+    return os.path.join(str(Path.home()), "data/power/")
+
+
+def create_connection():
+    return sqlite3.connect(os.path.join(get_data_path(), "power.dat"))
+
+
+if __name__ == '__main__':
+    con = get_db()
+    ticks = query_db("SELECT * FROM ticks")
+    for raw_tick in ticks:
+        timestamp = datetime.datetime(
+            year=raw_tick["year"],
+            month=raw_tick["month"],
+            day=raw_tick["day"],
+            hour=raw_tick["hour"],
+            minute=raw_tick["minute"],
+            second=raw_tick["second"],
+            microsecond=int(raw_tick["millis"]) * 1000,
+            tzinfo=tz.tzutc())
+
+        params = {
+            "source": 23,
+            "timestamp": timestamp.isoformat()
+        }
+
+        print("Converting tick to pulse: {} : {}".format(23, timestamp.isoformat()))
+
+        cur = con.cursor()
+        cur.execute("INSERT INTO pulse VALUES(:source, :timestamp)", params)
+        cur.close()
+    con.commit()
+


### PR DESCRIPTION
Fixes #2 with some major Changes
- Changed the structure of the database. It turns out that the SQLite
   has a decent support for date handling even though there is no actual
   datetime type for a column.
   - A new table 'pulse' has been created to replace 'ticks'
   - This new table has TEXT column 'timestamp' that holds an ISO
     formatted string.
   - Additionally, there is a new column source, as a preparation for
     multiple watt-meters
 - All data has been migrated to the new table (using a handy script).
   Fortunately, there was no major disruption to the data collection.
 - Web application draws the data from the new table now. Filtering
   works flawlessly.
 - Some minor refactoring to replace the word 'tick' with 'pulse'. It
   was incorrect in the first place.