### PR TITLE
Pool Heating Control Implementation

### DIFF
--- a/python/power/.idea/misc.xml
+++ b/python/power/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (RaspberryPi)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
   <component name="PyCharmProfessionalAdvertiser">
     <option name="shown" value="true" />
   </component>

--- a/python/power/.idea/misc.xml
+++ b/python/power/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (RaspberryPi)" project-jdk-type="Python SDK" />
   <component name="PyCharmProfessionalAdvertiser">
     <option name="shown" value="true" />
   </component>

--- a/python/power/.idea/power.iml
+++ b/python/power/.idea/power.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.9" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/python/power/.idea/power.iml
+++ b/python/power/.idea/power.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.8" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/python/power/aseko.py
+++ b/python/power/aseko.py
@@ -6,7 +6,7 @@ import aioaseko
 
 async def main():
     async with ClientSession() as session:
-        account = aioaseko.MobileAccount(session, "usr", "pwd")
+        account = aioaseko.MobileAccount(session, "user", "password")
         try:
             await account.login()
         except aioaseko.InvalidAuthCredentials:
@@ -19,6 +19,11 @@ async def main():
             print(f"Water flow: {unit.water_flow}")
             for variable in unit.variables:
                 print(variable.name, variable.current_value, variable.unit)
+
+            if unit.has_error:
+                for error in unit.errors:
+                    print(error.type, error.title, error.content)
+
         await account.logout()
 
 run(main())

--- a/python/power/pool.py
+++ b/python/power/pool.py
@@ -337,9 +337,9 @@ if __name__ == '__main__':
     parser.add_argument("-fsa" "--filtration_started_at", dest="fsa", type=str,
                         help="Specify when the filtration was started at (useful for restarts)")
     parser.add_argument("-qip" "--mqtt_ip", dest="mqtt_ip", type=str,
-                        help="IP Address of the MQTT broker for Power system configuration.")
+                        help="IP Address of the MQTT broker for various integrations.")
     parser.add_argument("-qp" "--mqtt_port", dest="mqtt_port", type=int,
-                        help="Port of the MQTT broker for Power system configuration.")
+                        help="Port of the MQTT broker for various integrations.")
 
     args = parser.parse_args()
 
@@ -364,7 +364,7 @@ if __name__ == '__main__':
     mqtt_client.loop_start()
 
     # Then, schedule a job to check the Solar status every 15 minutes
-    main_job = schedule.every(config.scheduler.period_minutes).minutes.do(evaluate_power_availability)
+    filtration_job = schedule.every(config.scheduler.period_minutes).minutes.do(evaluate_power_availability)
 
     # Run the job immediately after a startup
     schedule.run_all()
@@ -388,8 +388,8 @@ if __name__ == '__main__':
             updated_config_sync.release()
 
             # Reschedule the main job (in case the period has changed)
-            schedule.cancel_job(main_job)
-            main_job = schedule.every(config.scheduler.period_minutes).minutes.do(evaluate_power_availability)
+            schedule.cancel_job(filtration_job)
+            filtration_job = schedule.every(config.scheduler.period_minutes).minutes.do(evaluate_power_availability)
 
             # And finally, run immediately, just to recheck with the new configuration
             schedule.run_all()

--- a/python/power/pool.py
+++ b/python/power/pool.py
@@ -394,4 +394,7 @@ if __name__ == '__main__':
             # And finally, run immediately, just to recheck with the new configuration
             schedule.run_all()
 
+        # Just to prevent a tight-loop
+        time.sleep(1)
+
     mqtt_client.loop_stop(force=False)

--- a/python/power/shelly.py
+++ b/python/power/shelly.py
@@ -23,7 +23,7 @@ def on_connect(client, userdata, flags, rc):
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.
     client.subscribe("shellypro1pm-ec62608ab640/debug/log")
-    client.subscribe("power/pool")
+    client.subscribe("power/pool/#")
 
 
 # The callback for when a PUBLISH message is received from the server.

--- a/shell/power-start.sh
+++ b/shell/power-start.sh
@@ -9,6 +9,6 @@ sleep 5s
 sleep 5s
 /usr/bin/screen -dmS hm python3 /home/pi/power/homemonitor.py -u vizudum -p vizudum --host 192.168.88.120
 sleep 5s
-/usr/bin/screen -dmS pool python3 /home/pi/power/pool.py -gu "user" -gp "password" -mi "TPJ4CD602H" -pi "1419399" -rip "192.168.88.73" -ridx 0 -qip 192.168.88.48  -qp 1883
+/usr/bin/screen -dmS pool python3 /home/pi/power/pool.py -gu "user" -gp "password" -mi "TPJ4CD602H" -pi "1419399" -rip "192.168.88.73" -pridx 0 -eridx 2 -qip 192.168.88.48  -qp 1883
 sleep 5s
 /usr/bin/screen -dmS shelly python3 /home/pi/power/shelly.py -mip 192.168.88.48  -mp 1883

--- a/shell/power-start.sh
+++ b/shell/power-start.sh
@@ -9,6 +9,6 @@ sleep 5s
 sleep 5s
 /usr/bin/screen -dmS hm python3 /home/pi/power/homemonitor.py -u vizudum -p vizudum --host 192.168.88.120
 sleep 5s
-/usr/bin/screen -dmS pool python3 /home/pi/power/pool.py -gu "user" -gp "password" -mi "TPJ4CD602H" -pi "1419399" -rip "192.168.88.73" -pridx 0 -eridx 2 -qip 192.168.88.48  -qp 1883
+/usr/bin/screen -dmS pool python3.11 --growatt_user "user" --growatt_password "password" --mix_id "TPJ4CD602H" --plant_id "1419399" --relay_ip_address "192.168.88.73" --pump_relay_index 0 --heating_relay_index 2 --mqtt_ip 192.168.88.48 --mqtt_port 1883 --aseko_user "user" --aseko_password "password"
 sleep 5s
 /usr/bin/screen -dmS shelly python3 /home/pi/power/shelly.py -mip 192.168.88.48  -mp 1883

--- a/shelly/heating_input.js
+++ b/shelly/heating_input.js
@@ -1,0 +1,22 @@
+let CONFIG = {
+  inputId: 2,
+  MQTTPublishTopic: "power/pool/heating",
+};
+
+function debugMessage(message) {
+    print(message);
+    
+    if (MQTT.isConnected()) {
+        MQTT.publish("power/pool/debug", message, 2, false);
+    } else {
+        
+        print("MQTT NOT Connected");
+    }
+}
+
+Shelly.addStatusHandler(function(eventData) {
+    if (eventData.component === "input:" + JSON.stringify(CONFIG.inputId)) {
+        debugMessage("Announcing " + JSON.stringify(eventData) + " " + CONFIG.MQTTPublishTopic);
+        MQTT.publish(CONFIG.MQTTPublishTopic, JSON.stringify(eventData), 2, true);
+    }
+});


### PR DESCRIPTION
**shelly/humidity_control.js**

 - Improved logging over MQTT - uses specialized topics for different type of messages

**shelly/heating_input.js**

- New script to run on the 4P shelly to subscribe on the input status updates (input is connected to the Aseko, heating control)
- Publishes any updates on the input over MQTT

**shell/power-start.sh**

- Added new parameters to the pool startup script: Aseko API user/password, heating relay switch index
- Switched from single dash parameters to double dash parameters for readability
- Changed pool script interpreter from python3 to python3.11 (needed for aioaseko)

**python/power/aseko.py**

- Just a few changes that I did for testing
- Eventually, I will likely remove this script anyway

**python/power/pool.py**

- subscribed to the appropriate MQTT topic for heating input updates
- for now, maintaining 27-28 temperature
- it turns out that just having the input ON/OFF is enough to know whether to start or stop the heating - no need to check filtration status or anything (when filtration is OFF, Aseko will always turn off the heating input, otherwise, we switch on the heating only when the temperature is within the threshold)
- We have two switches now so improved the control functions to be able to control both
- Improved logging to include the heating switch into the statuses
- Still need to move some of the values into configuration

**python/power/shelly.py**

- Now subscribed to all subtopics of power topic
