### PR TITLE
Pool Heating - A few fixes

### DIFF
--- a/python/power/pool.py
+++ b/python/power/pool.py
@@ -161,6 +161,7 @@ def handle_heating_input_update(message):
 
             if heating_job is not None:
                 schedule.cancel_job(heating_job)
+                heating_job = None
 
             if old_switch_status != input_status:
                 if toggle_switch(args.heating_relay_index, current_status=old_switch_status, new_status=input_status):


### PR DESCRIPTION
- Heating job is properly reset to None when heating is stopped
- Retry counters have been fixed so that there are only 10 and not 11 attempts :-)
- Added exception handling to the `evaluate_pool_water_heating` similar to `evaluate_power_availability`
- Added infinite retry loops for key inputs in the heating control (similar to filtration control)
- Added infinite retry loop for heating toggle switch when requested by the control unit (the request will not come again until the next update, which could be several hours)
- Factored out the infinite retries into dedicated `_guaranteed` methods and using them at places where we simply have to wait until we manage to succeed (like in the point above)